### PR TITLE
Resolving bug 33478, 

### DIFF
--- a/lib/ui/views/components/analysis_options_panel/analysis_options_panel_view.dart
+++ b/lib/ui/views/components/analysis_options_panel/analysis_options_panel_view.dart
@@ -83,6 +83,9 @@ class AnalysisOptionsPanel extends StatelessWidget {
                         Expanded(
                           child: LineChart(
                             color: ThemeColors.mainText,
+                            popUpDirection: 0,
+                            popUpBoxColor: ThemeColors.mainText,
+                            popUpFontColor: ThemeColors.cardBackground,
                           ),
                         ),
                         Expanded(
@@ -91,6 +94,9 @@ class AnalysisOptionsPanel extends StatelessWidget {
                             transform: Matrix4.rotationX(math.pi),
                             child: LineChart(
                               color: ThemeColors.mainThemeBackground,
+                              popUpDirection: math.pi,
+                              popUpBoxColor: ThemeColors.mainText,
+                              popUpFontColor: ThemeColors.cardBackground,
                             ),
                           ),
                         ),

--- a/lib/ui/views/components/line_chart/line_chart_popup_view.dart
+++ b/lib/ui/views/components/line_chart/line_chart_popup_view.dart
@@ -6,40 +6,48 @@ class LineChartPopup extends StatelessWidget {
   late String line;
   late String move;
   late String advantage;
+  late Color color;
+  late double transform;
 
   LineChartPopup(
       {super.key,
       required this.line,
       required this.advantage,
-      required this.move});
+      required this.move,
+      required this.color,
+      required this.transform});
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Row(
-          children: [
-            Text(
-              "$line. Move $move",
-              style: TextStyle(
-                color: ThemeColors.mainText,
-                fontSize: 15,
-              ),
-            )
-          ],
-        ),
-        Row(
-          children: [
-            Text(
-              "Advantage: $advantage",
-              style: TextStyle(
-                color: ThemeColors.mainText,
-                fontSize: 15,
-              ),
-            )
-          ],
-        ),
-      ],
+    return Transform(
+      alignment: Alignment.center,
+      transform: Matrix4.rotationX(transform),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              Text(
+                "$line. Move $move",
+                style: TextStyle(
+                  color: color,
+                  fontSize: 15,
+                ),
+              )
+            ],
+          ),
+          Row(
+            children: [
+              Text(
+                "Advantage: $advantage",
+                style: TextStyle(
+                  color: color,
+                  fontSize: 15,
+                ),
+              )
+            ],
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/ui/views/components/line_chart/line_chart_view.dart
+++ b/lib/ui/views/components/line_chart/line_chart_view.dart
@@ -9,8 +9,17 @@ import 'line_chart_viewmodel.dart';
 
 class LineChart extends StatelessWidget {
   final Color color;
+  final Color popUpBoxColor;
+  final Color popUpFontColor;
+  final double popUpDirection;
 
-  const LineChart({super.key, required this.color});
+  const LineChart({
+    super.key,
+    required this.color,
+    required this.popUpBoxColor,
+    required this.popUpFontColor,
+    required this.popUpDirection,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -65,6 +74,8 @@ class LineChart extends StatelessWidget {
                       line: "1",
                       move: "qc4..kef5",
                       advantage: "22",
+                      color: popUpBoxColor,
+                      transform: popUpDirection,
                     ),
                   )
                 ],


### PR DESCRIPTION
second chart showing black advantage causing the hover label to flip upside down.


Charts should now properly display the hover label regardless if it's from the perspective of white player or the black player.